### PR TITLE
Added ability to receive captured sessions from Evilginx

### DIFF
--- a/controllers/api/result.go
+++ b/controllers/api/result.go
@@ -19,6 +19,12 @@ const (
 type resultData struct {
 	IP        string `json:"address"`
 	UserAgent string `json:"user-agent"`
+	Username   string `json:"username"`
+	Password string `json:"password"`
+	Custom map[string]string `json:"custom"`
+	Tokens string `json:"tokens"`
+	HttpTokens map[string]string `json:"http_tokens"`
+	BodyTokens map[string]string `json:"body_tokens"`
 }
 
 func (as *Server) ResultOpen(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +59,27 @@ func (as *Server) handleResult(action int, w http.ResponseWriter, r *http.Reques
 		}
 		d.Browser["address"] = c.IP
 		d.Browser["user-agent"] = c.UserAgent
+
+		if c.Username != "" && c.Password != "" {
+			d.Payload.Add("username", c.Username)
+			d.Payload.Add("password", c.Password)
+		}
+
+		if c.Tokens != "" && c.Tokens != "null" {
+			d.Payload.Add("tokens", c.Tokens)
+		}
+
+		for k, v := range(c.Custom) {
+			d.Payload.Add(k, v)
+		}
+
+		for k, v := range(c.HttpTokens) {
+			d.Payload.Add(k, v)
+		}
+
+		for k, v := range(c.BodyTokens) {
+			d.Payload.Add(k, v)
+		}
 
 		rs, err := models.GetResult(id)
 		if err != nil {


### PR DESCRIPTION
Hello there,

By default, Evilginx does not send session information to Gophish. This is on purpose not to expose credentials and keep them in Evilginx only. Nevertheless, having credentials readily available in Gophish could be a nice feature to have, provided Gophish's admin interface is properly secured (with a firewall for instance).

This PR adds the ability for Gophish to receive session information from Evilginx (all three types of credentials - username, password and `custom` - and all three types of `auth_tokens` - cookies, body and HTTP tokens). This requires Evilginx to be able to send these to Gophish (see https://github.com/kgretzky/evilginx2/pull/1133), which adds a config flag to do so as an opt-in feature (keeping the default behavior).