### PR TITLE
fix: extract lure params before generating final phish url

### DIFF
--- a/evilginx/helpers.go
+++ b/evilginx/helpers.go
@@ -53,3 +53,40 @@ func CreatePhishUrl(base_url string, params *url.Values) string {
 	}
 	return ret
 }
+
+func ExtractParams(u *url.URL) url.Values {
+	ret := make(url.Values)
+	vals := u.Query()
+
+	var enc_key string
+
+	for _, v := range vals {
+		if len(v[0]) > 8 {
+			enc_key = v[0][:8]
+			enc_vals, err := base64.RawURLEncoding.DecodeString(v[0][8:])
+			if err == nil {
+				dec_params := make([]byte, len(enc_vals)-1)
+
+				var crc byte = enc_vals[0]
+				c, _ := rc4.NewCipher([]byte(enc_key))
+				c.XORKeyStream(dec_params, enc_vals[1:])
+
+				var crc_chk byte
+				for _, c := range dec_params {
+					crc_chk += byte(c)
+				}
+
+				if crc == crc_chk {
+					params, err := url.ParseQuery(string(dec_params))
+					if err == nil {
+						for kk, vv := range params {
+							ret.Set(kk, vv[0])
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	return ret
+}

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -54,7 +54,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 	baseURL.RawQuery = ""
 
 	phishURL, _ := url.Parse(templateURL)
-	q := phishURL.Query()
+	q := evilginx.ExtractParams(phishURL)
 	phishURL.RawQuery = ""
 
 	q.Set("fname", r.FirstName)


### PR DESCRIPTION
Hello,

When sending a campaign, the generation of the phishing URL by Gophish embeds the obfuscated version of the lure parameters added by Evilginx instead of the deobfuscated version. Gophish indeed doesn't extract query parameters before obfuscating the phishing URL, resulting in a nested obfuscation, making lure parameters unusable.

Steps to reproduce:
1. Generate a lure with parameters in Evilginx
2. Launch a campaign in Gophish with the generated lure as landing

First email sent without the fix:

<img width="979" alt="image" src="https://github.com/user-attachments/assets/7c3dc342-039d-4f70-96ff-f391b2b7946a" />

![image](https://github.com/user-attachments/assets/453c3008-579f-4685-853c-bbb9e0b46584)

As we can see, the `pubkey` parameter added by Evilginx is obfuscated twice in the final URL. As such, it is unusable in redirectors or `js_inject` when hitting the landing page.

Second mail sent with the fix:

<img width="981" alt="image" src="https://github.com/user-attachments/assets/b4b41370-9ddf-4b0c-9b0f-459084c2aafd" />

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/3ddcaa3f-fe92-4719-a4fa-c8b4d8d535bc" />
