### PR TITLE
fix: set proper css for session label colour

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -409,7 +409,9 @@ p {
 .label-clicked {
     background-color: #F39C12 !important;
 }
-
+.label-session {
+    background-color: #000000 !important;
+}
 .gophish-editor {
     font-family: 'Courier New', Monospace !important;
     font-size: small !important;


### PR DESCRIPTION
Changes:
- Fixes `label-session` added in https://github.com/kgretzky/gophish/pull/4